### PR TITLE
Add DOI and release hash

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -31,6 +31,6 @@ identifiers:
     value: "https://github.com/Imageomics/saev/releases/tag/v0.1.0"
   - description: "The GitHub URL of the commit tagged with v0.1.0."
     type: url
-    value: "https://github.com/Imageomics/saev/tree/<commit-hash>" # Update on release
+    value: "https://github.com/Imageomics/saev/tree/def4457375c222cbd16e2e0caacaaa71a7fc551d" # Update on release
 version: 0.1.0
-#doi: <version-agnostic DOI from Zenodo>
+doi: 10.5281/zenodo.20753477

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![PyPI Downloads](https://static.pepy.tech/badge/saev)
 ![MIT License](https://img.shields.io/badge/License-MIT-efefef)
 ![GitHub Repo stars](https://img.shields.io/github/stars/Imageomics/saev?style=flat&label=GitHub%20%E2%AD%90)
+[![DOI](https://zenodo.org/badge/874858975.svg)](https://doi.org/10.5281/zenodo.20753477)
 
 Training sparse autoencoders (SAEs) on vision transformers (ViTs), implemented in PyTorch.
 


### PR DESCRIPTION
DOI is now part of the citation and I added the Zenodo DOI badge with the others at the top of the README.